### PR TITLE
Changed mode of log directory to become executable

### DIFF
--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -8,7 +8,7 @@
     group: "{{ item.group }}"
   with_items:
     - { path: "{{ gophish_install_destination }}",   user: "{{ gophish_user }}", group: "{{ gophish_user }}", mode: '0755' }
-    - { path: "{{ gophish_service_log_directory }}", user: "{{ gophish_user }}", group: "root",               mode: '0660' }
+    - { path: "{{ gophish_service_log_directory }}", user: "{{ gophish_user }}", group: "root",               mode: '0770' }
 
 - name: Install dependency packages.
   package:


### PR DESCRIPTION
Fixes systemd read errors. The current permissions set doesn't work with low privileged users: when running the systemd unit pointing to a low privilege log, the log file is unreadable since it is contained within a non-executable directory. See [here](https://askubuntu.com/a/83791) for more details.